### PR TITLE
Use single file to check for cached GraalVM installation

### DIFF
--- a/install-graalvm.sh
+++ b/install-graalvm.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ ! -d "/opt/graalvm-ce-1.0.0-rc16/bin/native-image" ]; then 
+if [ ! -f "/opt/graalvm-ce-1.0.0-rc16/bin/native-image" ]; then 
 	wget https://github.com/oracle/graal/releases/download/vm-1.0.0-rc16/graalvm-ce-1.0.0-rc16-linux-amd64.tar.gz -O /opt/graalvm-ce-1.0.0-rc16-linux-amd64.tar.gz
 	tar -xzf /opt/graalvm-ce-1.0.0-rc16-linux-amd64.tar.gz -C /opt
 fi

--- a/install-graalvm.sh
+++ b/install-graalvm.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ ! -d "/opt/graalvm-ce-1.0.0-rc16" ]; then 
+if [ ! -d "/opt/graalvm-ce-1.0.0-rc16/bin/native-image" ]; then 
 	wget https://github.com/oracle/graal/releases/download/vm-1.0.0-rc16/graalvm-ce-1.0.0-rc16-linux-amd64.tar.gz -O /opt/graalvm-ce-1.0.0-rc16-linux-amd64.tar.gz
 	tar -xzf /opt/graalvm-ce-1.0.0-rc16-linux-amd64.tar.gz -C /opt
 fi


### PR DESCRIPTION
Don't use the root folder, as it is created by Travis CI automatically.