### PR TITLE
Fixed Partner Display event

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 quarkus.ssl.native=true
 service.meetup.uri=https://api.meetup.com
 
-service.meetup.homeId=JUG-Mainz
+service.meetup.homeId=jug-mainz
 #partner meetups
 service.meetup.partnerIds=Cloud-Native-Night


### PR DESCRIPTION
meetup.com changed the "group URL" field from Uppercase "JUG-Mainz" to lowercase "jug-mainz". As the string comparison to find out if it is our event or a partner event is case sensitive, all events are displayed as "Partner Event". This config change which adapts the home id fixes this