### PR TITLE
Update to latest Quarkus version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0-SNAPSHOT</version>
     <properties>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
-        <quarkus.version>3.7.1</quarkus.version>
+        <quarkus.version>3.13.2</quarkus.version>
         <maven.compiler.source>21</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>21</maven.compiler.target>
@@ -29,12 +29,12 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy</artifactId>
+            <artifactId>quarkus-resteasy-reactive</artifactId>
         </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jsonb</artifactId>
+            <artifactId>quarkus-resteasy-reactive-jsonb</artifactId>
         </dependency>
 
         <dependency>
@@ -59,7 +59,7 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client</artifactId>
+            <artifactId>quarkus-rest-client-jsonb</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Switched to the reactive versions, because Quarkus now complains that you cannot mix reactive and non-reactive stack, and some of our smallrye dependencies seem to use the reactive stack. No changes in code or funtionality comes with this.

Fixes the following CVE:

![grafik](https://github.com/user-attachments/assets/8f53bcf9-c532-42f5-b0ef-e5322fc94d38)
